### PR TITLE
Credit reordering

### DIFF
--- a/src/components/common/CreditItem.tsx
+++ b/src/components/common/CreditItem.tsx
@@ -11,6 +11,9 @@ interface Props {
 	credit: Credit;
 	isEditable?: boolean;
 	onClick?: () => void;
+	moveItemUp: (index: number) => void;
+	moveItemDown: (index: number) => void;
+	key: number;
 }
 
 export default function CreditItem({ id, credit, isEditable, onClick }: Props) {

--- a/src/lib/classes.ts
+++ b/src/lib/classes.ts
@@ -201,6 +201,7 @@ export class PersonalLinks implements PersonalLinksParams {
  */
 export class Credit implements CreditParams {
 	id: string;
+	index?: number;
 	title: string;
 	jobTitle: string;
 	jobLocation: string;
@@ -215,6 +216,7 @@ export class Credit implements CreditParams {
 
 	constructor(params: CreditParams) {
 		this.id = params.id.toString();
+		this.index = params.index;
 		this.title = params.title ? params.title : '';
 		this.jobTitle = params.jobTitle ? params.jobTitle : '';
 		this.jobLocation = params.jobLocation ? params.jobLocation : '';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,7 @@ export interface UserProfileParams {
  */
 export interface CreditParams {
 	id: string | number; // Using a string here because we sometimes need to generate a unique ID for a new credit, and alphanumeric is better.
+	index?: number;
 	title?: string;
 	jobTitle?: string;
 	jobLocation?: string;

--- a/src/views/EditProfileView.tsx
+++ b/src/views/EditProfileView.tsx
@@ -27,6 +27,8 @@ import {
 	FiTrash,
 	FiTwitter,
 	FiXCircle,
+	FiArrowUpCircle,
+	FiArrowDownCircle,
 } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 import { Credit, UserProfile } from '../lib/classes';
@@ -119,6 +121,33 @@ export default function EditProfileView({ profile, profileLoading }: Props): JSX
 			setCreditsSorted(existingCredits.sort((a: Credit, b: Credit) => (a.year > b.year ? -1 : 1)));
 		}
 	}, [credits]);
+
+	// Moves a credit index up by one
+	const moveItemUp = (index: number) => {
+		if (index === 0) return;
+		const newOrder = [...creditsSorted];
+		const temp = newOrder[index - 1];
+		newOrder[index - 1] = newOrder[index];
+		newOrder[index] = temp;
+		setCreditsSorted(newOrder);
+	};
+	// Moves a credit index down by one
+	const moveItemDown = (index: number) => {
+		if (index === creditsSorted.length - 1) return;
+		const newOrder = [...creditsSorted];
+		const temp = newOrder[index + 1];
+		newOrder[index + 1] = newOrder[index];
+		newOrder[index] = temp;
+		setCreditsSorted(newOrder);
+	};
+
+	const handleMoveUp = (index: number) => {
+		moveItemUp(index);
+	};
+
+	const handleMoveDown = (index: number) => {
+		moveItemDown(index);
+	};
 
 	// Get all the selectable terms for the user taxonomies.
 	const [
@@ -554,13 +583,42 @@ export default function EditProfileView({ profile, profileLoading }: Props): JSX
 					{deleteCreditLoading ? (
 						<Spinner />
 					) : (
-						creditsSorted.map((credit: Credit) => (
+						creditsSorted.map((credit: Credit, index: number) => (
 							<Stack key={credit.id} direction='row' alignItems='center'>
 								<CreditItem
 									credit={credit}
 									onClick={() => handleEditCredit(credit.id)}
 									isEditable={true}
+									moveItemUp={() => {
+										moveItemUp(index);
+									}}
+									moveItemDown={() => {
+										moveItemDown(index);
+									}}
+									key={index}
 								/>
+								<Stack>
+									<IconButton
+										size='lg'
+										colorScheme='gray'
+										icon={<FiArrowUpCircle />}
+										aria-label='Move up Credit'
+										id={credit.id}
+										onClick={() => {
+											handleMoveUp(index);
+										}}
+									/>
+									<IconButton
+										size='lg'
+										colorScheme='gray'
+										icon={<FiArrowDownCircle />}
+										aria-label='Move down Credit'
+										id={credit.id}
+										onClick={() => {
+											handleMoveDown(index);
+										}}
+									/>
+								</Stack>
 								<IconButton
 									size='lg'
 									colorScheme='red'


### PR DESCRIPTION
- credit order can be changed by clicking up/down arrow
- each time a user reorders, it re-renders the list for immediate change
- this does not persist if I leave the edit profile page at this point (needs to be saved to the backend)
- All other functionalities (deleting, editing, adding) around credits works
- I ended up using [creditsSorted, setCreditsSorted] state to make the order change 